### PR TITLE
Pay for the call

### DIFF
--- a/TestScheduler
+++ b/TestScheduler
@@ -49,7 +49,12 @@ contract TestScheduler
         // the 4-byte signature of the scheduleCall function.
         bytes4 scheduleCallSig = bytes4(sha3("scheduleCall(bytes4,uint256)"));
 
-        scheduler.call(scheduleCallSig, sig, targetBlock);
+        // the amount of ether that must be paid for up front for the call.
+        // About 3/4 of this payment will be reimbursed once the call is
+        // executed.
+        uint endowment = tx.gasprice * 200000 + 2 * 20 finney;
+
+        scheduler.call.value(endowment)(scheduleCallSig, sig, targetBlock);
     }
 
     function scheduleLoopedCall() public
@@ -72,7 +77,12 @@ contract TestScheduler
         // the 4-byte signature of the scheduleCall function.
         bytes4 scheduleCallSig = bytes4(sha3("scheduleCall(bytes4,uint256)"));
 
-        scheduler.call(scheduleCallSig, sig, targetBlock);
+        // the amount of ether that must be paid for up front for the call.
+        // About 3/4 of this payment will be reimbursed once the call is
+        // executed.
+        uint endowment = tx.gasprice * 200000 + 2 * 20 finney;
+
+        scheduler.call.value(endowment)(scheduleCallSig, sig, targetBlock);
     }
 
     function returnFinney() public


### PR DESCRIPTION
# What was wrong?

The calls to `scheduleCall` did not include an ether value to pay for the call.

# How was it fixed

Sent along enough ether to pay for `200000 gas` and about 4x the current `defaultPayment` value.  About 3/4 of this ether will be returned when the call is scheduled.

#### Cute animal picture

![hat-on-a-cat-630x800](https://cloud.githubusercontent.com/assets/824194/13373556/0c0d603a-dd28-11e5-854d-e42ab0589a7b.jpg)
